### PR TITLE
add EAS update manually to Bare app 

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import {
   useColorScheme,
   View,
 } from 'react-native';
+import * as Updates from 'expo-updates';
 
 import {
   Colors,
@@ -30,6 +31,10 @@ type SectionProps = PropsWithChildren<{
 }>;
 
 function Section({children, title}: SectionProps): JSX.Element {
+  const runTypeMessage = Updates.isEmbeddedLaunch
+    ? 'This app is running from built-in code'
+    : 'This app is running an update';
+
   const isDarkMode = useColorScheme() === 'dark';
   return (
     <View style={styles.sectionContainer}>
@@ -51,6 +56,7 @@ function Section({children, title}: SectionProps): JSX.Element {
         ]}>
         {children}
       </Text>
+      <Text>{runTypeMessage}</Text>
     </View>
   );
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.INTERNET"/>
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme">
+    <meta-data android:name="expo.modules.updates.ENABLED" android:value="true"/>
+    <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="1.0.0"/>
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/fd6f91fb-6a39-44c1-b3ea-ce52135ad12d"/>
+    <meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY" android:value="{&quot;expo-channel-name&quot;:&quot;main&quot;}"/>
     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/app.json
+++ b/app.json
@@ -1,4 +1,19 @@
 {
   "name": "UsingExpoDemo2023",
-  "displayName": "UsingExpoDemo2023"
+  "displayName": "UsingExpoDemo2023",
+  "extra": {
+    "eas": {
+      "projectId": "fd6f91fb-6a39-44c1-b3ea-ce52135ad12d"
+    }
+  },
+  "owner": "keith-kurak",
+  "runtimeVersion": "1.0.0",
+  "updates": {
+    "url": "https://u.expo.dev/fd6f91fb-6a39-44c1-b3ea-ce52135ad12d",
+    "requestHeaders": {
+      "expo-channel-name": "main"
+    }
+  },
+  "android": {},
+  "ios": {}
 }

--- a/ios/Expo.plist
+++ b/ios/Expo.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>EXUpdatesCheckOnLaunch</key>
+    <string>ALWAYS</string>
+    <key>EXUpdatesEnabled</key>
+    <true/>
+    <key>EXUpdatesLaunchWaitMs</key>
+    <integer>0</integer>
+    <key>EXUpdatesRuntimeVersion</key>
+    <string>1.0.0</string>
+    <key>EXUpdatesURL</key>
+    <string>https://u.expo.dev/fd6f91fb-6a39-44c1-b3ea-ce52135ad12d</string>
+    <key>EXUpdatesRequestHeaders</key>
+    <dict>
+      <key>expo-channel-name</key>
+      <string>main</string>
+    </dict>
+  </dict>
+</plist>

--- a/ios/UsingExpoDemo2023.xcodeproj/project.pbxproj
+++ b/ios/UsingExpoDemo2023.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		533FE72829DF807E000611FD /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 533FE72729DF807E000611FD /* Expo.plist */; };
 		7699B88040F8A987B510C191 /* libPods-UsingExpoDemo2023-UsingExpoDemo2023Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-UsingExpoDemo2023-UsingExpoDemo2023Tests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		CAE24C622AFC4A3C64366DF2 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DD85F47B69DE378ACDAA05 /* ExpoModulesProvider.swift */; };
@@ -41,6 +42,7 @@
 		19F6CBCC0A4E27FBF8BF4A61 /* libPods-UsingExpoDemo2023-UsingExpoDemo2023Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-UsingExpoDemo2023-UsingExpoDemo2023Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4392A12AC88292D35C810B /* Pods-UsingExpoDemo2023.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UsingExpoDemo2023.debug.xcconfig"; path = "Target Support Files/Pods-UsingExpoDemo2023/Pods-UsingExpoDemo2023.debug.xcconfig"; sourceTree = "<group>"; };
 		4DDF4DDF38AC340B42991449 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-UsingExpoDemo2023-UsingExpoDemo2023Tests/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		533FE72729DF807E000611FD /* Expo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-UsingExpoDemo2023.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UsingExpoDemo2023.release.xcconfig"; path = "Target Support Files/Pods-UsingExpoDemo2023/Pods-UsingExpoDemo2023.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-UsingExpoDemo2023-UsingExpoDemo2023Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UsingExpoDemo2023-UsingExpoDemo2023Tests.debug.xcconfig"; path = "Target Support Files/Pods-UsingExpoDemo2023-UsingExpoDemo2023Tests/Pods-UsingExpoDemo2023-UsingExpoDemo2023Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-UsingExpoDemo2023.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-UsingExpoDemo2023.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -98,6 +100,7 @@
 		13B07FAE1A68108700A75B9A /* UsingExpoDemo2023 */ = {
 			isa = PBXGroup;
 			children = (
+				533FE72629DF8068000611FD /* Supporting */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.mm */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
@@ -125,6 +128,14 @@
 				5D127FF1F11C78B519D3035E /* UsingExpoDemo2023Tests */,
 			);
 			name = ExpoModulesProviders;
+			sourceTree = "<group>";
+		};
+		533FE72629DF8068000611FD /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				533FE72729DF807E000611FD /* Expo.plist */,
+			);
+			name = Supporting;
 			sourceTree = "<group>";
 		};
 		5D127FF1F11C78B519D3035E /* UsingExpoDemo2023Tests */ = {
@@ -271,6 +282,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				533FE72829DF807E000611FD /* Expo.plist in Resources */,
 				81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 			);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "expo": "^48.0.0",
     "expo-dev-client": "~2.1.6",
+    "expo-updates": "~0.16.4",
     "react": "18.2.0",
     "react-native": "0.71.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4016,6 +4016,11 @@ expo-dev-menu@2.1.4:
     expo-dev-menu-interface "1.1.1"
     semver "^7.3.5"
 
+expo-eas-client@~0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/expo-eas-client/-/expo-eas-client-0.5.1.tgz#3ef80dbbde13abe35be4e2a2e29b73d2f7fdf27a"
+  integrity sha512-i3L/iwhI6cFhSUpVsCxSU5qehNznL/rQFYoof6qUIh3CMyijCuTEwjEhwbw2a5W6obPBzQUXbomMSFDO6D5/0Q==
+
 expo-file-system@~15.2.0, expo-file-system@~15.2.2:
   version "15.2.2"
   resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-15.2.2.tgz#a1ddf8aabf794f93888a146c4f5187e2004683a3"
@@ -4066,10 +4071,32 @@ expo-modules-core@1.2.6:
     compare-versions "^3.4.0"
     invariant "^2.2.4"
 
+expo-structured-headers@~3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/expo-structured-headers/-/expo-structured-headers-3.1.1.tgz#198d44260f4b128d41313ef78df02fa6e20c5054"
+  integrity sha512-oV6yNGsJxQt7S9HYZTr+4L0I/yRwOF38USJ81I1KiN3GQI4C2z7P5OosyREA2VL9O+kUZVCCpNYsBLSa3/5bAQ==
+
 expo-updates-interface@~0.9.0:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/expo-updates-interface/-/expo-updates-interface-0.9.1.tgz#e81308d551ed5a4c35c8770ac61434f6ca749610"
   integrity sha512-wk88LLhseQ7LJvxdN7BTKiryyqALxnrvr+lyHK3/prg76Yy0EGi2Q/oE/rtFyyZ1JmQDRbO/5pdX0EE6QqVQXQ==
+
+expo-updates@~0.16.4:
+  version "0.16.4"
+  resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-0.16.4.tgz#6d05438cf7304add03645a598211ac4ef3cc4f64"
+  integrity sha512-hEUotP10sBiYn6dvkYC2rIa+kAmsBuaMp32sIVNAYEwKMQJqEwqNAKTU6CpJ4Aoc//BYL2Hv8qNo/UsT4rATRg==
+  dependencies:
+    "@expo/code-signing-certificates" "0.0.5"
+    "@expo/config" "~8.0.0"
+    "@expo/config-plugins" "~6.0.0"
+    "@expo/metro-config" "~0.7.0"
+    arg "4.1.0"
+    expo-eas-client "~0.5.0"
+    expo-manifests "~0.5.0"
+    expo-structured-headers "~3.1.0"
+    expo-updates-interface "~0.9.0"
+    fbemitter "^3.0.0"
+    resolve-from "^5.0.0"
 
 expo@^48.0.0:
   version "48.0.10"


### PR DESCRIPTION
Followed these instructions (mostly): https://docs.expo.dev/eas-update/eas-update-with-local-build/
Adapted with the values generated from a fresh `prebuild`
