### PR TITLE
Configure EAS build

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,6 +30,12 @@
           }
         }
       ]
-    ]
+    ],
+    "extra": {
+      "eas": {
+        "projectId": "fd6f91fb-6a39-44c1-b3ea-ce52135ad12d"
+      }
+    },
+    "owner": "keith-kurak"
   }
 }

--- a/app.json
+++ b/app.json
@@ -3,6 +3,7 @@
     "slug": "usingexpodemo2023",
     "name": "UsingExpoDemo2023",
     "icon": "./assets/icon.png",
+    "version": "1.0.0",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,34 @@
+{
+  "cli": {
+    "version": ">= 3.9.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "resourceClass": "m-medium"
+      }
+    },
+    "development-simulator": {
+      "extends": "development",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "resourceClass": "m-medium"
+      }
+    },
+    "production": {
+      "ios": {
+        "resourceClass": "m-medium"
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/eas.json
+++ b/eas.json
@@ -1,6 +1,7 @@
 {
   "cli": {
-    "version": ">= 3.9.0"
+    "version": ">= 3.9.0",
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -23,6 +24,7 @@
       }
     },
     "production": {
+      "autoIncrement": true,
       "ios": {
         "resourceClass": "m-medium"
       }


### PR DESCRIPTION
## Why
- Repeatable builds for everyone, no configuration on your machine!
- Manages credentials for both ad hoc and store builds
- Auto-submits to the stores after a successful build

## How
Followed directions at: https://docs.expo.dev/build/setup/

1. Ran `eas init` to setup project on EAS
2. Ran `eas build:configure` to setup build profiles in eas.json
3. Added `development-simulator` profile for iOS sims

Totally optional, but also setup:
  4. Version management to automatically increment the build number on each build

Finally, no changes checked in, but did the following to make distribution easier:
- Ran `eas credentials` and followed the prompts to create a device registration link so new devs can use the development build once I resign with `eas build:resign`
- Ran `eas submit --platform ios` and did the first-time setup wizard, so now I can automatically send builds to Testflight with the `--auto-submit` flag.

## Test Plan
- [x] Ran development builds for [iOS](https://expo.dev/accounts/keith-kurak/projects/usingexpodemo2023/builds/de66dc1f-3771-4d44-b7e3-876f7262b7de) and [Android](https://expo.dev/accounts/keith-kurak/projects/usingexpodemo2023/builds/a50632bf-dec7-42a3-801a-1e808fbe8dfa)
- [x] Ran production builds for iOS and Android