### PR TITLE
Configure EAS update

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,7 +37,7 @@
       }
     },
     "runtimeVersion": {
-      "policy": "sdkVersion"
+      "policy": "appVersion"
     },
     "updates": {
       "url": "https://u.expo.dev/fd6f91fb-6a39-44c1-b3ea-ce52135ad12d"

--- a/app.json
+++ b/app.json
@@ -30,6 +30,17 @@
           }
         }
       ]
-    ]
+    ],
+    "extra": {
+      "eas": {
+        "projectId": "fd6f91fb-6a39-44c1-b3ea-ce52135ad12d"
+      }
+    },
+    "runtimeVersion": {
+      "policy": "sdkVersion"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/fd6f91fb-6a39-44c1-b3ea-ce52135ad12d"
+    }
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -24,12 +24,14 @@
       }
     },
     "production": {
+      "channel": "production",
       "autoIncrement": true,
       "ios": {
         "resourceClass": "m-medium"
       }
     },
     "production-apk": {
+      "channel": "production",
       "android": {
         "buildType": "apk"
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "expo-dev-client": "~2.1.6",
     "expo-splash-screen": "~0.18.1",
     "expo-status-bar": "~1.4.4",
+    "expo-updates": "~0.16.4",
     "react": "18.2.0",
     "react-native": "0.71.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4061,6 +4061,11 @@ expo-dev-menu@2.1.4:
     expo-dev-menu-interface "1.1.1"
     semver "^7.3.5"
 
+expo-eas-client@~0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/expo-eas-client/-/expo-eas-client-0.5.1.tgz#3ef80dbbde13abe35be4e2a2e29b73d2f7fdf27a"
+  integrity sha512-i3L/iwhI6cFhSUpVsCxSU5qehNznL/rQFYoof6qUIh3CMyijCuTEwjEhwbw2a5W6obPBzQUXbomMSFDO6D5/0Q==
+
 expo-file-system@~15.2.0, expo-file-system@~15.2.2:
   version "15.2.2"
   resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-15.2.2.tgz#a1ddf8aabf794f93888a146c4f5187e2004683a3"
@@ -4124,10 +4129,32 @@ expo-status-bar@~1.4.4:
   resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.4.4.tgz#6874ccfda5a270d66f123a9f220735a76692d114"
   integrity sha512-5DV0hIEWgatSC3UgQuAZBoQeaS9CqeWRZ3vzBR9R/+IUD87Adbi4FGhU10nymRqFXOizGsureButGZIXPs7zEA==
 
+expo-structured-headers@~3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/expo-structured-headers/-/expo-structured-headers-3.1.1.tgz#198d44260f4b128d41313ef78df02fa6e20c5054"
+  integrity sha512-oV6yNGsJxQt7S9HYZTr+4L0I/yRwOF38USJ81I1KiN3GQI4C2z7P5OosyREA2VL9O+kUZVCCpNYsBLSa3/5bAQ==
+
 expo-updates-interface@~0.9.0:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/expo-updates-interface/-/expo-updates-interface-0.9.1.tgz#e81308d551ed5a4c35c8770ac61434f6ca749610"
   integrity sha512-wk88LLhseQ7LJvxdN7BTKiryyqALxnrvr+lyHK3/prg76Yy0EGi2Q/oE/rtFyyZ1JmQDRbO/5pdX0EE6QqVQXQ==
+
+expo-updates@~0.16.4:
+  version "0.16.4"
+  resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-0.16.4.tgz#6d05438cf7304add03645a598211ac4ef3cc4f64"
+  integrity sha512-hEUotP10sBiYn6dvkYC2rIa+kAmsBuaMp32sIVNAYEwKMQJqEwqNAKTU6CpJ4Aoc//BYL2Hv8qNo/UsT4rATRg==
+  dependencies:
+    "@expo/code-signing-certificates" "0.0.5"
+    "@expo/config" "~8.0.0"
+    "@expo/config-plugins" "~6.0.0"
+    "@expo/metro-config" "~0.7.0"
+    arg "4.1.0"
+    expo-eas-client "~0.5.0"
+    expo-manifests "~0.5.0"
+    expo-structured-headers "~3.1.0"
+    expo-updates-interface "~0.9.0"
+    fbemitter "^3.0.0"
+    resolve-from "^5.0.0"
 
 expo@~48.0.10:
   version "48.0.10"


### PR DESCRIPTION
## Why
I wanted to be able to update the JavaScript of the production app with a bugfix without publishing to the stores again.

## How
1. Ran `eas update:configure`
<img width="900" alt="image" src="https://user-images.githubusercontent.com/8053974/230997439-404caee8-c8a9-48bd-b7e5-ece84634c549.png">
2. Updated `runtimePolicy` to `appVersion` since our native dependencies might change on each app version.
3. Set `channel` for my production build profiles.

## Test Plan
- [x] Made a [new build](https://expo.dev/accounts/keith-kurak/projects/usingexpodemo2023/builds/cf2c1fa0-db50-4a19-a055-f2b4345f24e2), ran `eas update --branch production`, reloaded app, it was updated!